### PR TITLE
typo fix: Add missing 'v'

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ jobs:
       uses: flox/install-flox-action@v2
 
     - name: Build website
-      uses: flox/activate-action@1
+      uses: flox/activate-action@v1
       with:
         command: npm run build
 ```


### PR DESCRIPTION
This isn't huge, but it can surprise users trying to copy-paste from the code block into their action yaml.