### PR TITLE
Optionally start services

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,10 +16,13 @@ inputs:
   dir:
     description: "Path containing a .flox/ directory."
     default: null
+  start-services:
+    description: "Start services before running the command."
+    default: false
 
 runs:
   using: "composite"
   steps:
     - name: "Run flox activate"
       shell: "bash"
-      run: "flox activate ${{ inputs.environment != null && format('--remote={0}', inputs.environment) || '' }} ${{ inputs.dir != null && format('--dir={0}', inputs.dir) || '' }} -- ${{ inputs.command }}"
+      run: "flox activate ${{ inputs.environment != null && format('--remote={0}', inputs.environment) || '' }} ${{ inputs.dir != null && format('--dir={0}', inputs.dir) || '' }} ${{ inputs.start-services != true && '--start-services' || '' }} -- ${{ inputs.command }}"


### PR DESCRIPTION
A new option has been added to the action to start services when activating the environment. Similar to the CLI, services are not started by default and the `start-services` flag explicitly has to be set to `true`.