### PR TITLE
Address --remote removal in Flox 1.8.0 raised in issue#8

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,4 +22,4 @@ runs:
   steps:
     - name: "Run flox activate"
       shell: "bash"
-      run: "flox activate ${{ inputs.environment != null && format('--reference={0}', inputs.environment) || '' }} ${{ inputs.dir != null && format('--dir={0}', inputs.dir) || '' }} -- ${{ inputs.command }}"
+      run: "flox activate ${{ inputs.environment != null && format('-r={0}', inputs.environment) || '' }} ${{ inputs.dir != null && format('--dir={0}', inputs.dir) || '' }} -- ${{ inputs.command }}"

--- a/action.yml
+++ b/action.yml
@@ -22,4 +22,4 @@ runs:
   steps:
     - name: "Run flox activate"
       shell: "bash"
-      run: "flox activate ${{ inputs.environment != null && format('--remote={0}', inputs.environment) || '' }} ${{ inputs.dir != null && format('--dir={0}', inputs.dir) || '' }} -- ${{ inputs.command }}"
+      run: "flox activate ${{ inputs.environment != null && format('--reference={0}', inputs.environment) || '' }} ${{ inputs.dir != null && format('--dir={0}', inputs.dir) || '' }} -- ${{ inputs.command }}"


### PR DESCRIPTION
### Description
This PR updates the action to use the --reference flag in place of the removed --remote flag when activating an env. IT substitutes in the new --reference flag. Can be updated to `-r` for compat with both versions if people are using different versions of install action