### PR TITLE
fix: use -c to preserve behavior with 1.9.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,4 +22,4 @@ runs:
   steps:
     - name: "Run flox activate"
       shell: "bash"
-      run: "flox activate ${{ inputs.environment != null && format('-r={0}', inputs.environment) || '' }} ${{ inputs.dir != null && format('--dir={0}', inputs.dir) || '' }} -- ${{ inputs.command }}"
+      run: "flox activate ${{ inputs.environment != null && format('-r={0}', inputs.environment) || '' }} ${{ inputs.dir != null && format('--dir={0}', inputs.dir) || '' }} -c '${{ inputs.command }}'"


### PR DESCRIPTION
Flox 1.9.0 is replacing the previous behavior of `--` with `-c`. Update to use `-c`.

If we keep using `--`, that will prevent running shell commands like `cmd && cmd`, which seems undesirable