### PR TITLE
chore: pin GitHub Actions to SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,12 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v6"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
 
       - name: "Install Flox"
-        uses: "flox/install-flox-action@main"
+        uses: flox/install-flox-action@dc880156f423b1b9f03534c3ccbb3bc3bb8c223e # main
+
         with:
           channel: "${{ matrix.channel }}"
 


### PR DESCRIPTION
## Summary

Pin all external action references to immutable commit SHAs to mitigate supply chain attacks.

## Test plan

- [ ] CI passes

Tracking: https://github.com/flox/product/issues/1302