### PR TITLE
chore: rename action to "Flox Activate"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: "Run command in a Flox environment"
-description: "Runs a command in the context of the Flox environment."
-author: "flox <hello@floxdev.com>"
+name: "Flox Activate"
+description: "Run a command inside a Flox environment"
+author: "Flox <hello@flox.dev>"
 
 branding:
   color: "blue"


### PR DESCRIPTION
## Summary

Update the action's Marketplace metadata in preparation for publication:

- Rename the display name from `"Run command in a Flox environment"` to `"Flox Activate"`. The current name reads as a description; Marketplace conventions favor short, brand-first identifiers like `actions/checkout` or `docker/login-action`.
- Rewrite the description in imperative voice with no trailing period, per Marketplace description conventions.
- Capitalize `Flox` in the `author:` field and update the email from the outdated `floxdev.com` domain to `flox.dev`.

This is a metadata-only change. The `name:`, `description:`, and `author:` fields control the action's appearance on the Marketplace listing; they do not affect how consumers reference the action (`flox/activate-action@<ref>`). Existing workflows continue to work without modification.

Part of [ECO-60](https://linear.app/floxdotdev/issue/ECO-60/get-flox-github-actions-verified-by-github).

### Test plan

- [x] CI passes
- [ ] Visually confirm rendered name and description on the GitHub Marketplace listing preview when drafting a release