### PR TITLE
docs: fix README intro and update example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,6 @@
   Developer environments you can take with you
 </h2>
 
-<!-- TODO: here comes the graphic
- show immediate value proposition
- a short demo of basics would be good for now
- a bold statement: Free yourself from container walls.
--->
-
 <h3 align="center">
    &emsp;
    <a href="https://discourse.flox.dev"><b>Discourse</b></a>
@@ -42,7 +36,7 @@
   </a>
 </p>
 
-Runs command in the context of [Flox][flox-github] environment.
+Runs a command in the context of a [Flox][flox-github] environment.
 
 
 ## ⭐ Getting Started
@@ -61,23 +55,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Install flox
-      uses: flox/install-flox-action@v2
+      - name: Install Flox
+        uses: flox/install-flox-action@v2
 
-    - name: Build website
-      uses: flox/activate-action@v1
-      with:
-        command: npm run build
-        dir: ./frontend
+      - name: Build website
+        uses: flox/activate-action@v1
+        with:
+          command: npm run build
+          dir: ./frontend
 
-    - name: Activate remote environment
-      uses: flox/activate-action@v1
-      with:
-        environment: my-username/my-netlify-env
-        command: netlify deploy
+      - name: Activate remote environment
+        uses: flox/activate-action@v1
+        with:
+          environment: my-username/my-netlify-env
+          command: netlify deploy
 ```
 
 ## 📫 Have a question? Want to chat? Ran into a problem?


### PR DESCRIPTION
## Summary

Multiple small corrective fixes to `README.md`:

- Fix broken intro sentence. *"Runs command in the context of Flox environment"* was missing two articles; rewrite as *"Runs a command in the context of a Flox environment."*
- Update `actions/checkout@v3` to `@v4` in the example workflow.
- Capitalize the example step name `Install flox` to `Install Flox` to match the renamed sibling action.
- Indent the step items under `steps:` in the Getting Started example by two spaces. The compact form is technically valid YAML, but the indented form is the more common convention and friendlier to copy-paste into editors with strict linting. Mirrors the equivalent change in `flox/install-flox-action`.
- Remove a stale internal TODO HTML comment.

Part of [ECO-60](https://linear.app/floxdotdev/issue/ECO-60/get-flox-github-actions-verified-by-github) (follow-up README hygiene from the rename work).

### Test plan

- [x] CI passes
- [x] README renders cleanly on the repo page